### PR TITLE
amend modal backdrop stacking

### DIFF
--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -6,3 +6,12 @@
 @import "bottom_navbar";
 @import "card_rating_scale";
 @import "review_card";
+
+.modal-backdrop {
+  z-index: 1040 !important;
+}
+
+.modal {
+  z-index: 1050 !important;
+}
+  

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,3 +3,5 @@ import "@hotwired/turbo-rails"
 import "controllers"
 import "@popperjs/core"
 import "bootstrap"
+import "controllers/modal_cleanup"
+

--- a/app/javascript/controllers/modal_cleanup.js
+++ b/app/javascript/controllers/modal_cleanup.js
@@ -1,0 +1,35 @@
+// app/javascript/controllers/modal_cleanup.js
+
+document.addEventListener('DOMContentLoaded', () => {
+  console.log("Modal cleanup script loaded");
+
+  // Function to remove all modal backdrops
+  function removeBackdrops() {
+    console.log("Running backdrop cleanup");
+    document.querySelectorAll('.modal-backdrop').forEach(backdrop => backdrop.remove());
+  }
+
+  // Remove lingering backdrops when a modal is about to open
+  document.addEventListener('show.bs.modal', function () {
+    console.log("Opening modal - pre-emptive backdrop cleanup");
+    removeBackdrops();
+  });
+
+  // Remove backdrops after a modal is closed
+  document.addEventListener('hidden.bs.modal', function () {
+    console.log("Modal closed - running backdrop cleanup");
+    removeBackdrops();
+  });
+
+  // Remove backdrops before Turbo navigation to a new page
+  document.addEventListener('turbo:before-render', function () {
+    console.log("Turbo navigation - running backdrop cleanup");
+    removeBackdrops();
+  });
+
+  // Final backdrop check after Turbo renders a new page
+  document.addEventListener('turbo:render', function () {
+    console.log("Turbo render complete - final backdrop cleanup");
+    removeBackdrops();
+  });
+});


### PR DESCRIPTION
fix for issues with bootstrap modals

- when opening and closing a modal on one page it added `<div class="modal-backdrop fade show"></div>` above the `</body>` line of the HTML doc 

- when navigating to another page with modals (i.e. home page to profile page or show page) and opening a modal it would cause the background to be darker

- added a js modal_cleanup file in the javascript/controllers folder to remove any backdrops that could be leftover and caused the stacking (darkening of the background on subsequent modal being opened)
