### PR TITLE
add rating scale on keyup search, empty keyup search order

### DIFF
--- a/app/assets/stylesheets/components/_review_card.scss
+++ b/app/assets/stylesheets/components/_review_card.scss
@@ -128,7 +128,7 @@
         }
 
         .review-rating-number {
-          font-size: 12px;
+          font-size: 16px;
         }
       }
     }

--- a/app/controllers/cinemas_controller.rb
+++ b/app/controllers/cinemas_controller.rb
@@ -7,6 +7,7 @@ class CinemasController < ApplicationController
       @cinemas = Cinema.search_by_name_and_address(params[:query])
                        .order(Arel.sql("COALESCE(average_rating, 0) DESC"))
     else
+      params[:sorted_by]
       @cinemas = Cinema.all
                        .order(Arel.sql("COALESCE(average_rating, 0) DESC"))
     end

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -6,7 +6,6 @@ export default class extends Controller {
 
   connect() {
   //  console.log("autocomplete connected")
-  //  console.log(this.resultsTarget)
   }
 
   search(event) {
@@ -14,11 +13,10 @@ export default class extends Controller {
 
     // Exit early if the query is too short
     if (query.length < 1) {
-      this.resultsTarget.innerHTML = ""
-      return
+      // this.resultsTarget.innerHTML = ""
+      this.fetchAllCinemasSortedByRating();
+      return;
     }
-
-    // const url = `https://www.seated.movie/cinemas?query=${query}` && `http://localhost:3000/cinemas?query=${query}`
 
     const baseUrl = window.location.hostname.includes('localhost') ? 'http://localhost:3000' : 'https://www.seated.movie';
     const url = `${baseUrl}/cinemas?query=${query}`;
@@ -32,7 +30,6 @@ export default class extends Controller {
       },
       credentials: 'include'
     })
-    // .then(response => response.json())
     .then(response => {
       if (!response.ok) {
         throw new Error(`HTTP error! Status: ${response.status}`);
@@ -42,7 +39,31 @@ export default class extends Controller {
     .then((data) => {
       console.log(data)
       this.updateResults(data)
-      // this.resultsTarget.innerHTML(data.list)
+    })
+    .catch(error => console.error('Error:', error));
+  }
+
+  fetchAllCinemasSortedByRating() {
+    const baseUrl = window.location.hostname.includes('localhost') ? 'http://localhost:3000' : 'https://www.seated.movie';
+    const url = `${baseUrl}/cinemas?sorted_by=rating`;
+
+    fetch(url, {
+      headers: { 
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "X-Requested-With": "XMLHttpRequest"
+      },
+      credentials: 'include'
+    })
+    .then(response => {
+      if (!response.ok) {
+        throw new Error(`HTTP error! Status: ${response.status}`);
+      }
+      return response.json();
+    })
+    .then((data) => {
+      console.log("Displaying all cinemas sorted by rating:", data);
+      this.updateResults(data);
     })
     .catch(error => console.error('Error:', error));
   }
@@ -53,6 +74,29 @@ export default class extends Controller {
 
     // Populate the results
     cinemas.forEach(cinema => {
+
+      // Generate rating display as HTML
+      let ratingHtml = '<div class="review-card-rating large-rating">';
+      if (cinema.average_rating) {
+        const roundedRating = Math.floor(cinema.average_rating);
+        const partialRating = (cinema.average_rating % 1).toFixed(1);
+
+        // Render full rating images
+        for (let i = 0; i < roundedRating; i++) {
+          ratingHtml += `<img src="/assets/seated-emoji.png" alt="Red Rating Emoji" class="red-rating-image">`;
+        }
+
+        // Render a half rating image if partial rating >= 0.5
+        if (partialRating >= 0.5) {
+          ratingHtml += `<img src="/assets/seated-emoji.png" alt="Half Red Rating Emoji" class="half-red-rating-image">`;
+        }
+
+        ratingHtml += `<span class="review-rating-number">(${(Math.round(cinema.average_rating * 10) / 10).toFixed(1)})</span>`;
+      } else {
+        ratingHtml = `<span class="review-rating-number">No reviews yet</span>`;
+      }
+
+      // Create cinema card HTML
       const cinemaCard = `
         <div class="cinema-card">
           <a href="/cinemas/${cinema.id}">
@@ -65,7 +109,10 @@ export default class extends Controller {
             </div>
             <div class="cinema-card-extras">
               <p>${cinema.description}</p>
-              <p>Average rating: ${cinema.average_rating ? Math.round(cinema.average_rating * 10) / 10 : 'No reviews yet'}</p>
+              
+              <div class="cinema-list-average-rating large-rating review-rating-scale">
+                ${ratingHtml}
+              </div>
             </div>
           </a>
         </div>`

--- a/app/views/cinemas/_review.html.erb
+++ b/app/views/cinemas/_review.html.erb
@@ -101,7 +101,7 @@
             <%= image_tag 'seated-emoji.png', alt: 'Half Red Rating Emoji', class: 'half-red-rating-image' %>
           <% end %>
 
-          <span class="review-rating-number">(<%= review.rating.round(1) %>/5)</span>
+          <span class="review-rating-number">(<%= review.rating.round(1) %>)</span>
         <% else %>
           <span class="review-rating-number">No rating provided</span>
         <% end %>


### PR DESCRIPTION
- added chair rating scale to the keyup search results
- when a user types then deletes all text the default empty search box is now the same as the default page load order