### PR TITLE
amend review link to show page

### DIFF
--- a/app/assets/stylesheets/components/_review_card.scss
+++ b/app/assets/stylesheets/components/_review_card.scss
@@ -82,10 +82,11 @@
         background-color: transparent;
         border: none;
       }
+
       .review-image {
         display: block;
         flex-shrink: 0;
-        width: 70px;
+        // width: 70px;
         height: 70px;
         padding: 4px;
         border-radius: 8px;

--- a/app/assets/stylesheets/pages/_show.scss
+++ b/app/assets/stylesheets/pages/_show.scss
@@ -1,6 +1,6 @@
 
 .cinema-show-card {
-  padding: 16px;
+  padding-bottom: 16px;
   display: flex;
   flex-direction: column;
   background-color: #FBF7F5;
@@ -63,6 +63,7 @@
     a {
       color: #333;
       text-decoration: none;
+      font-size: 16px;
     }
   }
 

--- a/app/views/cinemas/_review.html.erb
+++ b/app/views/cinemas/_review.html.erb
@@ -34,6 +34,7 @@
         <span class="review-form-data"><strong><%= review.pref_seat %></strong></span>
       </p>
     </div>
+  <% end %>
     <div class="review-card-content">
       <div class="review-images">
         <% if review.photos.attached? %>
@@ -79,11 +80,14 @@
         <% end %>
       </div>
 
-      <div class="review-text">
-        <p>"<%= review.content %>"</p>
-      </div>
+      <%= link_to cinema_path(review.cinema) do %>
+        <div class="review-text">
+          <p>"<%= review.content %>"</p>
+        </div>
+      <% end %>
     </div>
 
+  <%= link_to cinema_path(review.cinema) do %>
     <div class="review-rating-scale">
 
       <div class="review-card-rating">

--- a/app/views/cinemas/show.html.erb
+++ b/app/views/cinemas/show.html.erb
@@ -2,64 +2,66 @@
   <div class="container">
     <div class="row">
       <div class="col">
-        <div class="cinema-show-card">
+        <div class="home-contents">
+          <div class="cinema-show-card">
 
-          <h1> <%= @cinema.name %> </h1>
-          <img src="<%= @cinema.image_url %>" alt="<%= @cinema.name %>">
+            <h1> <%= @cinema.name %> </h1>
+            <img src="<%= @cinema.image_url %>" alt="<%= @cinema.name %>">
 
-          <div data-controller="favourite" class="cinema-show-links">
+            <div data-controller="favourite" class="cinema-show-links">
 
-            <div class="show-add-favourite">
+              <div class="show-add-favourite">
 
-              <p class="review-new-btn">
-                <%= link_to "Add review", new_cinema_review_path(@cinema), class: 'review-new-btn' %>
-              </p>
+                <p class="review-new-btn">
+                  <%= link_to "Add review", new_cinema_review_path(@cinema), class: 'review-new-btn' %>
+                </p>
 
-              <div id="toggle-favourite-<%= @cinema.id %>">
-                <%= render 'favourites/toggle_button', cinema: @cinema %>
+                <div id="toggle-favourite-<%= @cinema.id %>">
+                  <%= render 'favourites/toggle_button', cinema: @cinema %>
+                </div>
+
               </div>
 
-            </div>
+              <div class="cinema-back-rating">
+                <div class="show-back-btn">
+                  <%= link_to "↩ All cinemas", cinemas_path %>
+                </div>
+                <div class="cinema-show-average">
+                  <div class="cinema-average-rating">
+                    <% if @cinema.average_rating.present? %>
+                      <% rounded_rating = @cinema.average_rating.floor %>
+                      <% partial_rating = (@cinema.average_rating % 1).round(1) %>
 
-            <div class="cinema-back-rating">
-              <div class="show-back-btn">
-                <%= link_to "↩ All cinemas", cinemas_path %>
-              </div>
-              <div class="cinema-show-average">
-                <div class="cinema-average-rating">
-                  <% if @cinema.average_rating.present? %>
-                    <% rounded_rating = @cinema.average_rating.floor %>
-                    <% partial_rating = (@cinema.average_rating % 1).round(1) %>
+                      <% # Render the full rating images as red rating images %>
+                      <% rounded_rating.times do %>
+                        <%= image_tag 'seated-emoji.png', alt: 'Red Rating Emoji', class: 'red-rating-image' %>
+                      <% end %>
 
-                    <% # Render the full rating images as red rating images %>
-                    <% rounded_rating.times do %>
-                      <%= image_tag 'seated-emoji.png', alt: 'Red Rating Emoji', class: 'red-rating-image' %>
+                      <% # Render the half image as a half red rating image %>
+                      <% if partial_rating >= 0.5 %>
+                        <%= image_tag 'seated-emoji.png', alt: 'Half Red Rating Emoji', class: 'half-red-rating-image' %>
+                      <% end %>
+
+                      <span class="average-rating-number">(<%= @cinema.average_rating.round(1) %>)</span>
+                    <% else %>
+                      <span class="average-rating-number">No reviews yet</span>
                     <% end %>
-
-                    <% # Render the half image as a half red rating image %>
-                    <% if partial_rating >= 0.5 %>
-                      <%= image_tag 'seated-emoji.png', alt: 'Half Red Rating Emoji', class: 'half-red-rating-image' %>
-                    <% end %>
-
-                    <span class="average-rating-number">(<%= @cinema.average_rating.round(1) %>)</span>
-                  <% else %>
-                    <span class="average-rating-number">No reviews yet</span>
-                  <% end %>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
+
+          <div class="cinema-review-cards">
+            <h2> Our community </h2>
+
+            <% @reviews.each do |review| %>
+                <%= render partial: 'cinemas/review', locals: { review: review, cinema: @cinema } %>
+            <% end %>
+
+          </div>
+
         </div>
-
-        <div class="cinema-review-cards">
-          <h2> Our community </h2>
-
-          <% @reviews.each do |review| %>
-              <%= render partial: 'cinemas/review', locals: { review: review, cinema: @cinema } %>
-          <% end %>
-
-        </div>
-
       </div>
     </div>
   </div>


### PR DESCRIPTION
problem: 
reviews with images attached prevented the user from getting to the show page when clicking the review text or rating scale, it should feel like clicking the whole card takes the user to the show page (aside from image modal and voting/commenting

solution:
instead of having one link_to that wraps the review card div from the top up to the vote/comment div (the image modal broke the link), added a link_to for the top section up until the image modal div, and added another link_to for the review-text div, and another for the review-rating-scale div

result: 
all of card, aside from image thumbnail, and vote/comment section redirects to the cinema show page

also additional minor tweaks to styling on the show page so it is more uniform across whole app