### PR TITLE
Search rating scale

### DIFF
--- a/app/assets/stylesheets/components/_card_rating_scale.scss
+++ b/app/assets/stylesheets/components/_card_rating_scale.scss
@@ -50,3 +50,8 @@
 .cinema-show-card .cinema-average-rating {
   @extend .large-rating;
 }
+
+.keyup-results .red-rating-image,
+.keyup-results .half-red-rating-image {
+  margin-right: 5.5px;
+}

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -71,36 +71,40 @@ export default class extends Controller {
 
   updateResults(cinemas) {
     // Clear current results
-    this.resultsTarget.innerHTML = ""
+    this.resultsTarget.innerHTML = "";
+
+    // Create a wrapping container for the cinema cards
+    const cinemaCardsWrapper = document.createElement("div");
+    cinemaCardsWrapper.className = "cinema-cards";
 
     // Populate the results
     cinemas.forEach(cinema => {
 
       // Generate rating display as HTML
-      let ratingHtml = '<div class="review-card-rating large-rating">';
+      let ratingHtml = "";
       if (cinema.average_rating) {
         const roundedRating = Math.floor(cinema.average_rating);
         const partialRating = (cinema.average_rating % 1).toFixed(1);
 
         // Render full rating images
         for (let i = 0; i < roundedRating; i++) {
-          ratingHtml += `<img src="${this.seatedEmojiPath}" alt="Red Rating Emoji" class="red-rating-image">`;
+          ratingHtml += `<img alt="Red Rating Emoji" class="red-rating-image" src="${this.seatedEmojiPath}">`;
         }
 
         // Render a half rating image if partial rating >= 0.5
         if (partialRating >= 0.5) {
-          ratingHtml += `<img src="${this.seatedEmojiPath}" alt="Half Red Rating Emoji" class="half-red-rating-image">`;
+          ratingHtml += `<img alt="Half Red Rating Emoji" class="half-red-rating-image" src="${this.seatedEmojiPath}">`;
         }
 
-        ratingHtml += `<span class="review-rating-number">(${(Math.round(cinema.average_rating * 10) / 10).toFixed(1)})</span>`;
+        ratingHtml += `<span class="average-rating-number">(${(Math.round(cinema.average_rating * 10) / 10).toFixed(1)})</span>`;
       } else {
-        ratingHtml = `<span class="review-rating-number">No reviews yet</span>`;
+        ratingHtml = `<span class="average-rating-number">No reviews yet</span>`;
       }
 
       // Create cinema card HTML
       const cinemaCard = `
-        <div class="cinema-card">
-          <a href="/cinemas/${cinema.id}">
+        <a href="/cinemas/${cinema.id}">
+          <div class="cinema-card">
             <div class="cinema-card-location">
               <h1>${cinema.name}</h1>
               <h5>${cinema.address}</h5>
@@ -111,13 +115,17 @@ export default class extends Controller {
             <div class="cinema-card-extras">
               <p>${cinema.description}</p>
               
-              <div class="cinema-list-average-rating large-rating review-rating-scale">
+              <div class="cinema-list-average-rating">
                 ${ratingHtml}
               </div>
             </div>
-          </a>
-        </div>`
-      this.resultsTarget.insertAdjacentHTML('beforeend', cinemaCard)
+          </div>
+        </a>`
+      // this.resultsTarget.insertAdjacentHTML('beforeend', cinemaCard)
+      cinemaCardsWrapper.insertAdjacentHTML("beforeend", cinemaCard);
     });
+
+    // Append the wrapper to the results target
+    this.resultsTarget.appendChild(cinemaCardsWrapper);
   }
 }

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -38,8 +38,8 @@ export default class extends Controller {
       return response.json()
     })
     .then((data) => {
-      console.log(data)
-      this.updateResults(data)
+      // console.log(data)
+      this.updateResults(data, true) // Pass true for keyup results
     })
     .catch(error => console.error('Error:', error));
   }
@@ -69,13 +69,18 @@ export default class extends Controller {
     .catch(error => console.error('Error:', error));
   }
 
-  updateResults(cinemas) {
+  updateResults(cinemas, isKeyup = false) {
     // Clear current results
     this.resultsTarget.innerHTML = "";
 
     // Create a wrapping container for the cinema cards
     const cinemaCardsWrapper = document.createElement("div");
     cinemaCardsWrapper.className = "cinema-cards";
+
+    // Add a specific class if the results are from keyup
+    if (isKeyup) {
+      cinemaCardsWrapper.classList.add("keyup-results");
+    }
 
     // Populate the results
     cinemas.forEach(cinema => {


### PR DESCRIPTION
Problem: 
Rating scale spacing differed on the cinema cards after the search depending on the search type. On page load and search form submission the rating scale chairs were further apart (correct) compared to the keyup autocomplete search results (too close together)

Solution: 
Added margin-right to the keyup results through the autocomplete js controller by adding a class with this margin when a keyup occurs.
Also ensured all the classes were matching from the keyup results vs the page load/form submission results (I tried this first but this alone didn't fix the problem)